### PR TITLE
Initial Import

### DIFF
--- a/vertx-on-lambda/.editorconfig
+++ b/vertx-on-lambda/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true

--- a/vertx-on-lambda/.gitignore
+++ b/vertx-on-lambda/.gitignore
@@ -1,0 +1,13 @@
+# build files
+target
+build
+lib_managed
+# runtime files
+node_modules
+.vertx
+# ide
+.classpath
+.project
+.idea
+.vscode
+

--- a/vertx-on-lambda/.mvn/wrapper/maven-wrapper.properties
+++ b/vertx-on-lambda/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,1 @@
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.0/apache-maven-3.5.0-bin.zip

--- a/vertx-on-lambda/README.md
+++ b/vertx-on-lambda/README.md
@@ -1,0 +1,73 @@
+# aws-lambda-vertx-native
+
+### Custom Vert.x Native for AWS Lambda
+
+*Disclaimer - This project should be considered a POC and has not been tested or verified for production use.
+If you decided to run this on production systems you do so at your own risk.*
+
+### Building this Runtime
+
+
+#### Prerequisites
+
+Make sure you have the following installed on your build machine before getting started.
+
+* GraalVM
+* AWS CLI
+
+##### Compile the Runtime Classes
+
+```
+$ ./mvnw package
+```
+
+If your system cannot build working images (say to mismatch of library versions), you can build under docker.
+
+```
+docker run --rm -it -v $(pwd):/work oracle/graalvm-ce:19.1.0 \
+  /bin/bash -c "gu install native-image && cd /work && ./mvnw package"
+```
+
+### Deploying to AWS Lambda
+
+#### Create a lambda role
+
+```
+aws iam create-role \
+    --role-name lambda-role \
+    --path "/service-role/" \
+    --assume-role-policy-document file:///tmp/trust-policy.json
+```
+
+Where the file `/tmp/trust-policy.json` contains:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+#### Create a function
+
+```
+aws lambda delete-function --function-name vertxNativeTester
+
+aws lambda create-function --function-name vertxNativeTester \
+    --zip-file fileb://target/lambda-0.0.1-SNAPSHOT-function.zip --handler lambda.ApplicationLoadBalancerLambda --runtime provided \
+    --role arn:aws:iam::985727241951:role/service-role/lambda-role
+```
+
+#### Test it
+
+```
+aws lambda invoke --function-name vertxNativeTester  --payload '{"message":"Hello World"}' --log-type Tail response.txt | grep "LogResult"| awk -F'"' '{print $4}' | base64 --decode
+```

--- a/vertx-on-lambda/build.sh
+++ b/vertx-on-lambda/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker run --rm -it -v $(pwd):/work oracle/graalvm-ce:19.1.0 /bin/bash -c "gu install native-image && cd /work && ./mvnw clean package"
+
+echo deploy ./target/myapp-0.0.1-SNAPSHOT-aws-function.zip to AWS Lambda

--- a/vertx-on-lambda/pom.xml
+++ b/vertx-on-lambda/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>myapp</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <name>vertx_on_lambda</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <graal.version>19.1.0</graal.version>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.testSource>1.8</maven.compiler.testSource>
+    <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>3.7.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>xyz.jetdrone</groupId>
+      <artifactId>vertx.lambda</artifactId>
+      <version>0.0.4</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.oracle.substratevm</groupId>
+        <artifactId>native-image-maven-plugin</artifactId>
+        <version>${graal.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>native-image</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>xyz.jetdrone.vertx.lambda.aws.Bootstrap</mainClass>
+          <imageName>bootstrap</imageName>
+          <buildArgs>--report-unsupported-elements-at-runtime --allow-incomplete-classpath --no-server</buildArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.1.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>xyz.jetdrone</groupId>
+            <artifactId>vertx.lambda</artifactId>
+            <version>0.0.4</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>aws-function</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/vertx-on-lambda/serverless.yml
+++ b/vertx-on-lambda/serverless.yml
@@ -1,0 +1,22 @@
+service: vertx-on-lambda
+
+provider:
+  name: aws
+  runtime: provided
+  stage: dev
+  region: ap-northeast-1
+  endpointType: REGIONAL
+  tracing:
+    apiGateway: true
+    lambda: true
+
+package:
+  artifact: target/myapp-0.0.1-SNAPSHOT-aws-function.zip
+
+functions:
+  hello:
+    handler: com.example.vertx.on.lambda.HelloWorldLambda
+    events:
+      - http: ANY /
+      - http: 'ANY {proxy+}'
+

--- a/vertx-on-lambda/src/main/java/com/example/vertx/on/lambda/HelloWorldLambda.java
+++ b/vertx-on-lambda/src/main/java/com/example/vertx/on/lambda/HelloWorldLambda.java
@@ -1,0 +1,31 @@
+package com.example.vertx.on.lambda;
+
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
+import xyz.jetdrone.vertx.lambda.Lambda;
+
+/**
+ * You can use a Lambda function to process any kind of events.
+ * AWS Lambda sends events as JSON messages so it is convenient
+ * to let use the generified interface.
+ *
+ * As a utility helper most events can be converted to POJOs
+ * by using the provided implementations under the <pre>event</pre>
+ * package.
+ */
+public class HelloWorldLambda implements Lambda<JsonObject> {
+
+  @Override
+  public void handle(Message<JsonObject> event) {
+
+    final String responseBody = "Hello world!";
+
+    event.reply(
+      new JsonObject()
+        .put("statusCode", 200)
+        .put("body", responseBody)
+        .put("isBase64Encoded", false)
+        .put("headers", new JsonObject()
+          .put("X-Powered-By", "AWS Lambda & Eclipse Vert.x")));
+  }
+}

--- a/vertx-on-lambda/src/main/resources/META-INF/services/xyz.jetdrone.vertx.lambda.Lambda
+++ b/vertx-on-lambda/src/main/resources/META-INF/services/xyz.jetdrone.vertx.lambda.Lambda
@@ -1,0 +1,2 @@
+# List all available Lambdas here
+com.example.vertx.on.lambda.HelloWorldLambda

--- a/vertx-on-lambda/src/test/java/com/example/vertx/on/lambda/HelloWorldLambdaTest.java
+++ b/vertx-on-lambda/src/test/java/com/example/vertx/on/lambda/HelloWorldLambdaTest.java
@@ -1,0 +1,57 @@
+package com.example.vertx.on.lambda;
+
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import xyz.jetdrone.vertx.lambda.Lambda;
+
+import java.util.ServiceLoader;
+
+@RunWith(VertxUnitRunner.class)
+public class HelloWorldLambdaTest {
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
+
+  @Before
+  public void beforeTest() {
+    // register all lambda's into the eventbus
+    ServiceLoader<Lambda> serviceLoader = ServiceLoader.load(Lambda.class);
+    for (Lambda fn : serviceLoader) {
+      fn.init(rule.vertx());
+      rule.vertx().eventBus().localConsumer(fn.getClass().getName(), fn);
+    }
+  }
+
+  @Test
+  public void shouldGetAnEchoMessage(TestContext should) {
+    final Async test = should.async();
+    final EventBus eb = rule.vertx().eventBus();
+
+    eb.<JsonObject>send(HelloWorldLambda.class.getName(), new JsonObject(), msg -> {
+      if (msg.failed()) {
+        should.fail(msg.cause());
+      } else {
+        final JsonObject response = msg.result().body();
+
+        // validate the reply
+        should.assertEquals(200, response.getInteger("statusCode"));
+        should.assertEquals("Hello world!", response.getString("body"));
+        should.assertEquals(false, response.getBoolean("isBase64Encoded"));
+
+        JsonObject headers = response.getJsonObject("headers");
+        should.assertNotNull(headers);
+        should.assertEquals("AWS Lambda & Eclipse Vert.x", headers.getString("X-Powered-By"));
+
+        test.complete();
+      }
+    });
+  }
+}


### PR DESCRIPTION
@bnusunny this PR allows you to compare the vertx alternative of java native lambda's with the current mix you already have.

The vert.x alternative allows you to package multiple lambda's in a single deployment zip. A lambda is a java interface implementation see: [HelloWorldLambda.java](vertx-on-lambda/src/main/java/com/example/vertx/on/lambda/HelloWorldLambda.java)

Since vert.x doesn't make use of reflection and reflection is tricky with graal, all lambda's must be registered with a service loader [META-INF/services/xyz.jetdrone.vertx.lambda.Lambda](vertx-on-lambda/src/main/resources/META-INF/services/xyz.jetdrone.vertx.lambda.Lambda)

This means you can use the standard AWS configuration to select the handler to execute by using it's FQCN: https://github.com/bnusunny/supersonic-java-on-lambda/compare/vertx?expand=1#diff-75f3a0cdcf416b0d6b15c4fa6c82d1f1R18

Finally this approach allows you to test you code [HelloWorldLambdaTest.java](vertx-on-lambda/src/test/java/com/example/vertx/on/lambda/HelloWorldLambdaTest.java) before the native image build starts which means faster development turnaround.

/cc @smoell for any other input I might have missed.

